### PR TITLE
Add missing `Quote` Model

### DIFF
--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Quote extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'text',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [];
+}


### PR DESCRIPTION
Adding the missing Quote model. 

This model is used for a livewire search-case which isn't completely implemented in this project. Maybe Work in progress, maybe legacy. 

I added the model because now `php artisan migrate:fresh --seed` works again.

Other option is to remove the migration, seed and blades